### PR TITLE
Makes it possible to close DB connections

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,15 +2,13 @@ install: composer install --prefer-source --dev
 
 before_script:
   - echo 'extension = "memcached.so"' >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
-  - mysql -e "USE mysql;UPDATE user SET password=PASSWORD('password') WHERE user='root';FLUSH PRIVILEGES;"
   - mysql -e 'CREATE DATABASE phpar_test;'
   - psql -c 'CREATE DATABASE phpar_test;' -U postgres
-  - psql -c "ALTER USER postgres WITH PASSWORD 'password';" -U postgres
 
 services:
   - memcache
 
-env: PHPAR_MYSQL=mysql://root:password@127.0.0.1/phpar_test PHPAR_PGSQL=pgsql://postgres:password@127.0.0.1/phpar_test
+env: PHPAR_MYSQL=mysql://root@127.0.0.1/phpar_test PHPAR_PGSQL=pgsql://postgres@127.0.0.1/phpar_test
 
 language: php
 php:

--- a/lib/Connection.php
+++ b/lib/Connection.php
@@ -538,6 +538,12 @@ abstract class Connection
 		return false;
 	}
 
+  public function close()
+	{
+    // Clear reference to PDO conn so that PHP will garbage collect and trigger PDO to close DB conn
+    $this->conn = null;
+  }
+
 }
 
 ;

--- a/lib/ConnectionManager.php
+++ b/lib/ConnectionManager.php
@@ -13,7 +13,7 @@ class ConnectionManager extends Singleton
 {
 	/**
 	 * Array of {@link Connection} objects.
-	 * @var array
+	 * @var Connection[]
 	 */
 	static private $connections = array();
 
@@ -44,7 +44,10 @@ class ConnectionManager extends Singleton
 	public static function drop_connection($name=null)
 	{
 		if (isset(self::$connections[$name]))
-			unset(self::$connections[$name]);
+		{
+			self::$connections[$name]->close();
+      unset(self::$connections[$name]);
+    }
 	}
 }
 

--- a/lib/Model.php
+++ b/lib/Model.php
@@ -732,6 +732,16 @@ class Model
 		return static::table()->reestablish_connection();
 	}
 
+  /**
+   * Drops the database connection.
+   *
+   * @return void
+   */
+  public static function drop_connection()
+  {
+    return static::table()->drop_connection();
+  }
+
 	/**
 	 * Returns the {@link Table} object for this model.
 	 *

--- a/test/helpers/AdapterTest.php
+++ b/test/helpers/AdapterTest.php
@@ -89,8 +89,16 @@ class AdapterTest extends DatabaseTest
 		$conn = $this->conn;
 		$port = $conn::$DEFAULT_PORT;
 
-		if ($this->conn->protocol != 'sqlite')
-			ActiveRecord\Connection::instance("{$url['scheme']}://{$url['user']}:{$url['pass']}@{$url['host']}:$port{$url['path']}");
+		// Build the connection string with optional password
+    $connection_string = "{$url['scheme']}://{$url['user']}";
+    if(isset($url['pass'])){
+    	$connection_string = "{$connection_string}:{$url['pass']}";
+    }
+ 		$connection_string = "{$connection_string}@{$url['host']}:$port{$url['path']}";
+
+		if ($this->conn->protocol != 'sqlite') {
+      ActiveRecord\Connection::instance($connection_string);
+    }
 	}
 
 	/**


### PR DESCRIPTION
There's currently no way to close a PDO connection, which is problematic for long running processes. The net effect is that any system that is composed of a large number of long running processes will consume a connection for each process, which is highly unnecessary if the processes are rarely talking to the DB.

The essence of this issue that PDO only closes connections when the connection is deallocated (garbage collected), and that the following code does not correctly cause a deallocation of the PDO connection:

```php
use ActiveRecord\Config;
use ActiveRecord\ConnectionManager;
...
ConnectionManager::drop_connection(Config::instance()->get_default_connection());
```

This can be observed by setting up a DB connection, issuing a query, dropping the connection and then sleeping before exiting the program. Running `show processlist` in a MySQL console will show that a connection remains open (sleeping) even after the call to `drop_connection`.

To solve this problem, I've added a `drop_connection` method on Model.php. This causes all references to the PDO connection to be deallocated. Those references were in:
* Table.php which holds a reference to an instance of Connection.php which in turn holds a reference to a PDO connection
* ConnectionManager.php which holds a reference to an instance of Connection.php which in turn holds a reference to a PDO connection. In this latter case, the existing code was clearing the first reference, but not the reference from Connection.php to the PDO connection. The new `Connection#close` method now handles this.